### PR TITLE
in case of "connection reset by peer" or "broken pipe"

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -220,7 +220,17 @@ func (client *Client) sendCommand(cmd string, args ...string) (data interface{},
 		}
 
 		data, err = client.rawSend(c, b)
-	}
+    }
+
+    //in case of "connection reset by peer" or "broken pipe"
+    if err != nil {
+        msg := err.Error()
+        if strings.Contains(msg, "reset") || strings.Contains(msg, "broken"){
+            c.Close()
+            client.pushCon(nil)
+            return data, err
+        }
+    }
 
 	//add the client back to the queue
 	client.pushCon(c)


### PR DESCRIPTION
连接池中的某个连接如果正正好在发送命令时被服务端关闭，会报出connection reset by peer的错误，这条连接会变成死连接，但还继续存在连接池中，以后每次使用该连接时就会报broken pipe错误。因此应该将此中死连接从连接池中摘掉
//TODO
报reset by peer错后本次命令并未生效，对数据可靠性敏感的话，必须重新连接发送命令
