### PR TITLE
Fix bug: can not parse certain error bug

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -113,8 +113,8 @@ func readResponse(reader *bufio.Reader) (interface{}, error) {
 		return strings.TrimSpace(line[1:]), nil
 	}
 
-	if strings.HasPrefix(line, "-ERR ") {
-		errmesg := strings.TrimSpace(line[5:])
+	if line[0] == '-' {
+		errmesg := strings.TrimSpace(line[1:])
 		return nil, RedisError(errmesg)
 	}
 


### PR DESCRIPTION
For example authorization error in redis:
-NOAUTH Authentication required.
can not parse

Redis Protocol:
In RESP, the type of some data depends on the first byte:
For Simple Strings the first byte of the reply is "+"
For Errors the first byte of the reply is "-"
For Integers the first byte of the reply is ":"
For Bulk Strings the first byte of the reply is "$"
For Arrays the first byte of the reply is "*"

so just handle the first byte for error
